### PR TITLE
Enable to update context of args

### DIFF
--- a/factory/factory.go
+++ b/factory/factory.go
@@ -28,6 +28,7 @@ type Args interface {
 	Instance() interface{}
 	Parent() Args
 	Context() context.Context
+	UpdateContext(context.Context)
 	pipeline(int) *pipeline
 }
 


### PR DESCRIPTION
本家はメンテされてない？ぽいのでforkして修正してしまう
argsのcontextを更新する方法がない（CreateWithContextで生成したcontextを使い回すことしかできない）ので、factory内で状態を持つことが難しい

UpdateContextなる関数自体は存在するがinterfaceとして公開されていない（というか定義はしているが呼び出されている部分が存在しない）
これが意図的に隠しているのか分からないが、context内に状態を保存できると便利なので修正する